### PR TITLE
[readdcw] panic on silent watcher death

### DIFF
--- a/watcher_readdcw.go
+++ b/watcher_readdcw.go
@@ -9,6 +9,8 @@ package notify
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -367,7 +369,9 @@ func (r *readdcw) loop() {
 			r.loopevent(n, overEx)
 		}
 		if err = overEx.parent.readDirChanges(); err != nil {
-			// TODO: error handling
+			if os.Getenv("DV_DISABLE_NOTIFY_PANIC") == "" {
+				panic(fmt.Sprintf("notify: readDirChanges re-arm failed: %v", err))
+			}
 		}
 		r.loopstate(overEx)
 	}


### PR DESCRIPTION
## Summary

When the Windows IOCP loop's `readDirChanges()` re-arm fails, the error was silently dropped. The watcher then sat in `GetQueuedCompletionStatus` forever because nothing would post a completion for an un-armed watch. The agent had no log, no Sentry signal, no way to notice the watcher had died.

Now we panic. Process restart is the only recovery proven to work (in-process Stop/Watch can't clear the singleton's broken state -- the user in ONC-4744 tried six times). The panic message + stack trace flow through Go's stderr handler and the agent's `crashlog.go` into Sentry, so we also gain observability we never had.

`DV_DISABLE_NOTIFY_PANIC` is the support escape hatch in case some deterministic trigger surfaces and causes crashloop. Setting it falls back to today's silent-failure behavior.

See [DIV-10969](https://linear.app/diversion/issue/DIV-10969) for full design notes, ONC-4744 for the originating bundle.

## Test plan

- [ ] Build passes (`go build ./...`)
- [ ] Lands in a client release behind agent build; soak in dogfood for a week before broad rollout
- [ ] Confirm Sentry receives a notify panic event when the path is triggered (manual repro: recursive delete + parallel writes in a large watched repo on Windows). If we never see one, the bug class may be even rarer than feared, which is fine.