### PR TITLE
[notify] surface silent watcher failures via leveled logger

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -10,13 +10,28 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 )
+
+// firstEventOnce gates the one-shot "watcher is alive" info log emitted on
+// the first event dispatched to a user channel. Consumers tail their logs
+// for this line as evidence that the notify pipeline is wired up.
+var firstEventOnce sync.Once
+
+// logFirstEvent emits the one-shot heartbeat. Safe to call on every
+// dispatch -- only the first call produces a log line.
+func logFirstEvent(path string) {
+	firstEventOnce.Do(func() {
+		infof("first event dispatched (path=%q)", path)
+	})
+}
 
 // Level classifies log messages emitted by the notify package.
 type Level int
 
 const (
 	LevelDebug Level = iota
+	LevelInfo
 	LevelWarn
 	LevelError
 )
@@ -32,6 +47,12 @@ func SetLogger(fn func(Level, string, ...interface{})) {
 func debugf(format string, v ...interface{}) {
 	if logger != nil {
 		logger(LevelDebug, format, v...)
+	}
+}
+
+func infof(format string, v ...interface{}) {
+	if logger != nil {
+		logger(LevelInfo, format, v...)
 	}
 }
 
@@ -80,6 +101,8 @@ func init() {
 		logger = func(level Level, format string, v ...interface{}) {
 			prefix := "[D] "
 			switch level {
+			case LevelInfo:
+				prefix = "[I] "
 			case LevelWarn:
 				prefix = "[W] "
 			case LevelError:

--- a/debug.go
+++ b/debug.go
@@ -13,13 +13,8 @@ import (
 	"sync"
 )
 
-// firstEventOnce gates the one-shot "watcher is alive" info log emitted on
-// the first event dispatched to a user channel. Consumers tail their logs
-// for this line as evidence that the notify pipeline is wired up.
 var firstEventOnce sync.Once
 
-// logFirstEvent emits the one-shot heartbeat. Safe to call on every
-// dispatch -- only the first call produces a log line.
 func logFirstEvent(path string) {
 	firstEventOnce.Do(func() {
 		infof("first event dispatched (path=%q)", path)
@@ -39,7 +34,8 @@ const (
 var logger func(level Level, format string, v ...interface{})
 
 // SetLogger installs a leveled callback that receives all log messages emitted
-// by the notify package. Passing nil disables logging.
+// by the notify package. Call this before any Watch -- the package-level
+// logger var is not guarded by a mutex. Passing nil disables logging.
 func SetLogger(fn func(Level, string, ...interface{})) {
 	logger = fn
 }
@@ -74,7 +70,9 @@ func errorf(format string, v ...interface{}) {
 var dbgprintf = debugf
 
 var dbgprint = func(v ...interface{}) {
-	debugf("%s", fmt.Sprint(v...))
+	// fmt.Sprintln matches log.Println's spacing (single space between args);
+	// strip the trailing newline since debugf's consumer adds its own.
+	debugf("%s", strings.TrimRight(fmt.Sprintln(v...), "\n"))
 }
 
 func dbgcallstack(max int) []string {

--- a/debug.go
+++ b/debug.go
@@ -33,9 +33,7 @@ const (
 
 var logger func(level Level, format string, v ...interface{})
 
-// SetLogger installs a leveled callback that receives all log messages emitted
-// by the notify package. Call this before any Watch -- the package-level
-// logger var is not guarded by a mutex. Passing nil disables logging.
+// SetLogger must be called before any Watch -- logger is not mutex-guarded.
 func SetLogger(fn func(Level, string, ...interface{})) {
 	logger = fn
 }
@@ -64,14 +62,11 @@ func errorf(format string, v ...interface{}) {
 	}
 }
 
-// dbgprintf and dbgprint preserve the old call shape used throughout the
-// package; they route to debugf so existing call sites keep working without
-// modification.
+// Back-compat shims for existing dbgprint / dbgprintf call sites.
 var dbgprintf = debugf
 
 var dbgprint = func(v ...interface{}) {
-	// fmt.Sprintln matches log.Println's spacing (single space between args);
-	// strip the trailing newline since debugf's consumer adds its own.
+	// Sprintln (not Sprint) preserves Println-style spacing between args.
 	debugf("%s", strings.TrimRight(fmt.Sprintln(v...), "\n"))
 }
 

--- a/debug.go
+++ b/debug.go
@@ -5,15 +5,56 @@
 package notify
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"runtime"
 	"strings"
 )
 
-var dbgprint func(...interface{})
+// Level classifies log messages emitted by the notify package.
+type Level int
 
-var dbgprintf func(string, ...interface{})
+const (
+	LevelDebug Level = iota
+	LevelWarn
+	LevelError
+)
+
+var logger func(level Level, format string, v ...interface{})
+
+// SetLogger installs a leveled callback that receives all log messages emitted
+// by the notify package. Passing nil disables logging.
+func SetLogger(fn func(Level, string, ...interface{})) {
+	logger = fn
+}
+
+func debugf(format string, v ...interface{}) {
+	if logger != nil {
+		logger(LevelDebug, format, v...)
+	}
+}
+
+func warnf(format string, v ...interface{}) {
+	if logger != nil {
+		logger(LevelWarn, format, v...)
+	}
+}
+
+func errorf(format string, v ...interface{}) {
+	if logger != nil {
+		logger(LevelError, format, v...)
+	}
+}
+
+// dbgprintf and dbgprint preserve the old call shape used throughout the
+// package; they route to debugf so existing call sites keep working without
+// modification.
+var dbgprintf = debugf
+
+var dbgprint = func(v ...interface{}) {
+	debugf("%s", fmt.Sprint(v...))
+}
 
 func dbgcallstack(max int) []string {
 	pc, stack := make([]uintptr, max), make([]string, 0, max)
@@ -32,25 +73,19 @@ func dbgcallstack(max int) []string {
 	return stack
 }
 
-func SetLogger(print func(...interface{}), printf func(string, ...interface{})) {
-	dbgprint = print
-	dbgprintf = printf
-}
-
 func init() {
 	if _, ok := os.LookupEnv("NOTIFY_DEBUG"); ok || debugTag {
 		log.SetOutput(os.Stdout)
 		log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
-		dbgprint = func(v ...interface{}) {
-			v = append([]interface{}{"[D] "}, v...)
-			log.Println(v...)
+		logger = func(level Level, format string, v ...interface{}) {
+			prefix := "[D] "
+			switch level {
+			case LevelWarn:
+				prefix = "[W] "
+			case LevelError:
+				prefix = "[E] "
+			}
+			log.Printf(prefix+format, v...)
 		}
-		dbgprintf = func(format string, v ...interface{}) {
-			format = "[D] " + format
-			log.Printf(format, v...)
-		}
-		return
 	}
-	dbgprint = func(v ...interface{}) {}
-	dbgprintf = func(format string, v ...interface{}) {}
 }

--- a/tree_nonrecursive.go
+++ b/tree_nonrecursive.go
@@ -90,6 +90,7 @@ func (t *nonrecursiveTree) internal(rec <-chan EventInfo) {
 		if ei.Event() == Remove {
 			nd, err := t.root.Get(ei.Path())
 			if err != nil {
+				warnf("tree_nonrecursive: path lookup failed on Remove for %q: %v", ei.Path(), err)
 				t.rw.Unlock()
 				continue
 			}
@@ -298,9 +299,13 @@ func (t *nonrecursiveTree) Stop(c chan<- EventInfo) {
 		case diff == none:
 			return nil
 		case diff[1] == 0:
-			t.w.Unwatch(nd.Name)
+			if err := t.w.Unwatch(nd.Name); err != nil {
+				warnf("tree_nonrecursive: stop unwatch failed for %q: %v", nd.Name, err)
+			}
 		default:
-			t.w.Rewatch(nd.Name, diff[0], diff[1])
+			if err := t.w.Rewatch(nd.Name, diff[0], diff[1]); err != nil {
+				warnf("tree_nonrecursive: stop rewatch failed for %q: %v", nd.Name, err)
+			}
 		}
 		return nil
 	}

--- a/tree_nonrecursive.go
+++ b/tree_nonrecursive.go
@@ -38,6 +38,7 @@ func newNonrecursiveTree(w watcher, c, rec chan EventInfo) *nonrecursiveTree {
 func (t *nonrecursiveTree) dispatch(c <-chan EventInfo) {
 	for ei := range c {
 		dbgprintf("dispatching %v on %q", ei.Event(), ei.Path())
+		logFirstEvent(ei.Path())
 		t.dispatchEvent(ei)
 	}
 }

--- a/tree_recursive.go
+++ b/tree_recursive.go
@@ -127,6 +127,7 @@ func newRecursiveTree(w recursiveWatcher, c chan EventInfo) *recursiveTree {
 func (t *recursiveTree) dispatch() {
 	for ei := range t.c {
 		dbgprintf("dispatching %v on %q", ei.Event(), ei.Path())
+		logFirstEvent(ei.Path())
 		t.dispatchEvent(ei)
 	}
 }

--- a/tree_recursive.go
+++ b/tree_recursive.go
@@ -278,8 +278,7 @@ func (t *recursiveTree) Watch(path string, c chan<- EventInfo,
 			}
 			if e != nil {
 				err = nonil(err, e)
-				// TODO(rjeczalik): child is still watched, warn all its watchpoints
-				// about possible duplicate events via Error event
+				warnf("tree_recursive: child unwatch failed for %q during cleanup: %v", nd.Name, e)
 			}
 		}
 		return err

--- a/tree_recursive.go
+++ b/tree_recursive.go
@@ -279,6 +279,8 @@ func (t *recursiveTree) Watch(path string, c chan<- EventInfo,
 			}
 			if e != nil {
 				err = nonil(err, e)
+				// TODO(rjeczalik): child is still watched, warn all its watchpoints
+				// about possible duplicate events via Error event
 				warnf("tree_recursive: child unwatch failed for %q during cleanup: %v", nd.Name, e)
 			}
 		}

--- a/watcher_fsevents.go
+++ b/watcher_fsevents.go
@@ -66,7 +66,7 @@ func (w *watch) Dispatch(ev []FSEvent) {
 		dbgprintf("%v (0x%x) (%s, i=%d, ID=%d, len=%d)\n", Event(ev[i].Flags),
 			ev[i].Flags, ev[i].Path, i, ev[i].ID, len(ev))
 		if ev[i].Flags&failure != 0 && failure&events == 0 {
-			// TODO(rjeczalik): missing error handling
+			errorf("FSEvents reported failure flag (0x%x) for %s -- events may be lost", ev[i].Flags, ev[i].Path)
 			continue
 		}
 		if !strings.HasPrefix(ev[i].Path, w.path) {

--- a/watcher_inotify.go
+++ b/watcher_inotify.go
@@ -223,7 +223,9 @@ func (i *inotify) loop(esch chan<- []*event) {
 func (i *inotify) read() (es []*event) {
 	n, err := unix.Read(int(i.fd), i.buffer[:])
 	if err != nil || n < unix.SizeofInotifyEvent {
-		if err != nil {
+		// EINTR and EAGAIN are recoverable -- a signal interrupted the syscall
+		// or the non-blocking fd had no data ready. Don't surface as errors.
+		if err != nil && !errors.Is(err, unix.EINTR) && !errors.Is(err, unix.EAGAIN) {
 			errorf("inotify Read failed: %v", err)
 		}
 		return

--- a/watcher_inotify.go
+++ b/watcher_inotify.go
@@ -223,8 +223,7 @@ func (i *inotify) loop(esch chan<- []*event) {
 func (i *inotify) read() (es []*event) {
 	n, err := unix.Read(int(i.fd), i.buffer[:])
 	if err != nil || n < unix.SizeofInotifyEvent {
-		// EINTR and EAGAIN are recoverable -- a signal interrupted the syscall
-		// or the non-blocking fd had no data ready. Don't surface as errors.
+		// EINTR / EAGAIN are recoverable, not errors.
 		if err != nil && !errors.Is(err, unix.EINTR) && !errors.Is(err, unix.EAGAIN) {
 			errorf("inotify Read failed: %v", err)
 		}

--- a/watcher_inotify.go
+++ b/watcher_inotify.go
@@ -199,10 +199,12 @@ func (i *inotify) loop(esch chan<- []*event) {
 				i.Lock()
 				defer i.Unlock()
 				if err = unix.Close(int(fd)); err != nil && err != unix.EINTR {
+					errorf("inotify close(2) failed during shutdown: %v", err)
 					panic("notify: close(2) error " + err.Error())
 				}
 				atomic.StoreInt32(&i.fd, invalidDescriptor)
 				if err = i.epollclose(); err != nil && err != unix.EINTR {
+					errorf("inotify epollclose failed during shutdown: %v", err)
 					panic("notify: epollclose error " + err.Error())
 				}
 				close(esch)
@@ -221,6 +223,9 @@ func (i *inotify) loop(esch chan<- []*event) {
 func (i *inotify) read() (es []*event) {
 	n, err := unix.Read(int(i.fd), i.buffer[:])
 	if err != nil || n < unix.SizeofInotifyEvent {
+		if err != nil {
+			errorf("inotify Read failed: %v", err)
+		}
 		return
 	}
 	var sys *unix.InotifyEvent

--- a/watcher_kqueue.go
+++ b/watcher_kqueue.go
@@ -86,7 +86,7 @@ func (k *kq) Record(w *watched) {
 // Del implements trigger.
 func (k *kq) Del(w *watched) {
 	if err := syscall.Close(w.fd); err != nil {
-		warnf("kqueue: fd close failed in Del: %v", err)
+		warnf("kqueue: fd close failed in Del (path=%q, fd=%d): %v", w.p, w.fd, err)
 	}
 	delete(k.idLkp, w.fd)
 	delete(k.pthLkp, w.p)

--- a/watcher_kqueue.go
+++ b/watcher_kqueue.go
@@ -85,7 +85,9 @@ func (k *kq) Record(w *watched) {
 
 // Del implements trigger.
 func (k *kq) Del(w *watched) {
-	syscall.Close(w.fd)
+	if err := syscall.Close(w.fd); err != nil {
+		warnf("kqueue: fd close failed in Del: %v", err)
+	}
 	delete(k.idLkp, w.fd)
 	delete(k.pthLkp, w.p)
 }

--- a/watcher_readdcw.go
+++ b/watcher_readdcw.go
@@ -356,6 +356,7 @@ func (r *readdcw) loop() {
 			return
 		}
 		if overlapped == nil {
+			// TODO: check key == rewatch delete or 0(panic)
 			warnf("readdcw: unexpected nil overlapped (key=%#x, transferred=%d)", key, n)
 			continue
 		}

--- a/watcher_readdcw.go
+++ b/watcher_readdcw.go
@@ -356,7 +356,7 @@ func (r *readdcw) loop() {
 			return
 		}
 		if overlapped == nil {
-			// TODO: check key == rewatch delete or 0(panic)
+			warnf("readdcw: unexpected nil overlapped (key=%#x)", key)
 			continue
 		}
 		overEx := (*overlappedEx)(unsafe.Pointer(overlapped))
@@ -367,7 +367,7 @@ func (r *readdcw) loop() {
 			r.loopevent(n, overEx)
 		}
 		if err = overEx.parent.readDirChanges(); err != nil {
-			// TODO: error handling
+			errorf("readDirChanges re-arm failed: %v", err)
 		}
 		r.loopstate(overEx)
 	}

--- a/watcher_readdcw.go
+++ b/watcher_readdcw.go
@@ -356,7 +356,7 @@ func (r *readdcw) loop() {
 			return
 		}
 		if overlapped == nil {
-			warnf("readdcw: unexpected nil overlapped (key=%#x)", key)
+			warnf("readdcw: unexpected nil overlapped (key=%#x, transferred=%d)", key, n)
 			continue
 		}
 		overEx := (*overlappedEx)(unsafe.Pointer(overlapped))
@@ -367,7 +367,7 @@ func (r *readdcw) loop() {
 			r.loopevent(n, overEx)
 		}
 		if err = overEx.parent.readDirChanges(); err != nil {
-			errorf("readDirChanges re-arm failed: %v", err)
+			errorf("readDirChanges re-arm failed for %q: %v", syscall.UTF16ToString(overEx.parent.pathw), err)
 		}
 		r.loopstate(overEx)
 	}


### PR DESCRIPTION
## Summary

ONC-4744: the agent's Windows watcher silently stopped delivering events after a `ReadDirectoryChangesW` re-arm failure -- agent kept running but stopped seeing file changes. Took ~24h of investigation to find because the lib swallowed the error at a `// TODO: error handling`.

A fork-wide audit found 9 similar silent-failure sites across all four platform implementations:

| File | Site | Level |
|---|---|---|
| `watcher_readdcw.go` | `readDirChanges` re-arm failure (the original bug) | error |
| `watcher_readdcw.go` | `overlapped == nil` with unexpected key | warn |
| `watcher_inotify.go` | `unix.Read` failure on inotify fd | error |
| `watcher_inotify.go` | close / epollclose failure during shutdown (existing panic kept) | error |
| `watcher_fsevents.go` | FSEvents failure flags (dropped events / must rescan) | error |
| `watcher_kqueue.go` | `syscall.Close` on watched fd failure in Del | warn |
| `tree_recursive.go` | child Unwatch failure during multi-child cleanup | warn |
| `tree_nonrecursive.go` | path lookup failure on Remove | warn |
| `tree_nonrecursive.go` | Unwatch / Rewatch errors in Stop's fn callback | warn |

## The change

- Replace the debug-only `SetLogger(print, printf)` with a single leveled callback `SetLogger(fn func(Level, string, ...))`. Existing `dbgprint` / `dbgprintf` call sites keep working via back-compat shims at debug level. **Breaking change to `SetLogger`, but our only consumer is DiversionCompany/diversion**, which migrates in DiversionCompany/diversion#7957.
- Add `LevelInfo` and emit a one-shot "first event dispatched" heartbeat from the tree dispatcher so consumers have a positive "watcher is alive" signal in their logs.
- Wire each of the 9 audit sites through the new `errorf` / `warnf` helpers. **Watcher behavior is unchanged everywhere** -- this PR only adds visibility.

## Why not panic / error-channel

Two more aggressive alternatives were considered and rejected on the Linear ticket:
- **Panic + restart** (PR #3, now closed): too risky -- could crashloop on a deterministic trigger; process-wide blast radius.
- **Error channel + workspace pause**: premature -- we have no behavioral policy to enact yet; would be designing for hypothetical future behavior with zero data.

The plan is to re-evaluate behavioral response after ~2 weeks of Sentry data (tracked in DIV-10969).

## Test plan

- [x] Host build (`go build ./...`)
- [x] Cross-compile (linux, darwin, windows, freebsd)
- [x] `gofmt` clean on touched files
- [x] `staticcheck` -- no new findings on touched files (the two existing `unused` warnings predate this PR)
- [x] `go test ./...` -- the 4 macOS test failures present on `main` are pre-existing FSEvents flakes / stale fixtures, unaffected by this PR
- [x] Consumer-side end-to-end validation (DiversionCompany/diversion#7957):
  - Windows e2e (`workflow_dispatch` against `windows-2022`, `aws` backend) **passed**
  - Local Docker `test_basic` (Linux): agent log shows the new `INFO notify first event dispatched (path=...)` heartbeat
  - Warn-level path also fired in the same run -- real `tree_nonrecursive: stop unwatch failed` warnings observed at workspace teardown
- [ ] After merge: tag v0.9.16 and consume from the client (DiversionCompany/diversion#7957)