### PR TITLE
[notify] recreate watch handle after a failed Windows completion

### DIFF
--- a/watcher_readdcw.go
+++ b/watcher_readdcw.go
@@ -364,7 +364,12 @@ func (r *readdcw) loop() {
 		if overEx == nil || overEx.parent == nil {
 			dbgprintf("incomplete completion status transferred=%d, overlapped=%#v, key=%#b", n, overEx, key)
 			continue
-		} else if n != 0 {
+		}
+		if err != nil {
+			r.handleFailedCompletion(overEx, err)
+			continue
+		}
+		if n != 0 {
 			r.loopevent(n, overEx)
 		}
 		if err = overEx.parent.readDirChanges(); err != nil {
@@ -374,10 +379,44 @@ func (r *readdcw) loop() {
 	}
 }
 
+// handleFailedCompletion handles a completion packet dequeued with an error:
+// the pending ReadDirectoryChangesW I/O failed (volume reset, aborted by a
+// filter driver, handle closed outside the package). Re-arming the same handle
+// can report success while the OS never posts a completion for it again, which
+// leaves the watch silently dead -- so open a fresh handle instead. Failures
+// caused by our own unwatch/rewatch teardown keep the old state-machine path.
+func (r *readdcw) handleFailedCompletion(overEx *overlappedEx, err error) {
+	g := overEx.parent
+	path := syscall.UTF16ToString(g.pathw)
+	r.Lock()
+	defer r.Unlock()
+	if g.parent.filter&onlyMachineStates != 0 {
+		// Unwatch/rewatch in progress: closing a handle aborts its pending I/O,
+		// so this failure is expected and the state machine must consume it.
+		dbgprintf("readdcw: completion failed during unwatch/rewatch for %q: %v", path, err)
+		r.loopstateLocked(overEx)
+		return
+	}
+	handle := syscall.Handle(atomic.LoadUintptr((*uintptr)(&g.handle)))
+	if handle == syscall.InvalidHandle {
+		dbgprintf("readdcw: completion failed for already-closed handle %q: %v", path, err)
+		return
+	}
+	errorf("readdcw: completion failed for %q: %v; recreating the watch handle", path, err)
+	syscall.CloseHandle(handle) // best effort: the handle is likely already dead
+	if regErr := g.register(r.cph); regErr != nil {
+		errorf("readdcw: failed to recreate the watch handle for %q, watch is dead: %v", path, regErr)
+	}
+}
+
 // TODO(pknap) : doc
 func (r *readdcw) loopstate(overEx *overlappedEx) {
 	r.Lock()
 	defer r.Unlock()
+	r.loopstateLocked(overEx)
+}
+
+func (r *readdcw) loopstateLocked(overEx *overlappedEx) {
 	filter := overEx.parent.parent.filter
 	if filter&onlyMachineStates == 0 {
 		return

--- a/watcher_readdcw.go
+++ b/watcher_readdcw.go
@@ -100,11 +100,19 @@ func (g *grip) register(cph syscall.Handle) (err error) {
 	); err != nil {
 		return
 	}
-	if _, err = syscall.CreateIoCompletionPort(g.handle, cph, 0, 0); err != nil {
-		syscall.CloseHandle(g.handle)
-		return
+	if _, err = syscall.CreateIoCompletionPort(g.handle, cph, 0, 0); err == nil {
+		err = g.readDirChanges()
 	}
-	return g.readDirChanges()
+	if err != nil {
+		// The handle was opened but never armed, so no completion will ever
+		// arrive for it. Close it and store InvalidHandle so the grip reads
+		// as dead everywhere, instead of leaking an open handle that a later
+		// closeHandle would close a second time (the value may be reused by
+		// the OS by then).
+		syscall.CloseHandle(g.handle)
+		atomic.StoreUintptr((*uintptr)(&g.handle), uintptr(syscall.InvalidHandle))
+	}
+	return
 }
 
 // readDirChanges tells the system to store file change information in grip's

--- a/watcher_readdcw_recovery_test.go
+++ b/watcher_readdcw_recovery_test.go
@@ -126,3 +126,41 @@ func TestRecreateHandleAfterFailedCompletion(t *testing.T) {
 
 	awaitEvent("after-recovery")
 }
+
+// TestRegisterFailureClosesHandle covers register failing after CreateFile
+// succeeded. Arming a plain file forces that: CreateFile and the completion
+// port association accept a file handle, but ReadDirectoryChangesW needs a
+// directory and fails. The grip must not keep the open, unarmed handle -- no
+// completion will ever arrive for it, so it must read as dead (InvalidHandle).
+func TestRegisterFailureClosesHandle(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "plain.txt")
+	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	pathw, err := syscall.UTF16FromString(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cph, err := syscall.CreateIoCompletionPort(syscall.InvalidHandle, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateIoCompletionPort: %v", err)
+	}
+	defer syscall.CloseHandle(cph)
+
+	g := &grip{
+		handle:   syscall.InvalidHandle,
+		filter:   uint32(Write),
+		pathw:    pathw,
+		ovlapped: &overlappedEx{},
+	}
+	g.ovlapped.parent = g
+
+	if err := g.register(cph); err == nil {
+		t.Fatal("register on a plain file should fail at readDirChanges")
+	}
+	if g.handle != syscall.InvalidHandle {
+		t.Fatalf("failed register left an open handle: %v", g.handle)
+	}
+}

--- a/watcher_readdcw_recovery_test.go
+++ b/watcher_readdcw_recovery_test.go
@@ -1,0 +1,128 @@
+//go:build windows
+// +build windows
+
+package notify
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+var procCancelIoExRecovery = modkernel32.NewProc("CancelIoEx")
+
+type logCapture struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (lc *logCapture) log(_ Level, format string, v ...interface{}) {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	lc.msgs = append(lc.msgs, fmt.Sprintf(format, v...))
+}
+
+func (lc *logCapture) contains(substr string) bool {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	for _, m := range lc.msgs {
+		if strings.Contains(m, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRecreateHandleAfterFailedCompletion covers handleFailedCompletion: a
+// pending ReadDirectoryChangesW that fails outside our own unwatch/rewatch
+// must be answered by recreating the handle, and the watch must stay alive.
+//
+// CancelIoEx aborts the pending I/O the way a filter driver or a volume reset
+// does: the completion port receives a packet with ERROR_OPERATION_ABORTED and
+// zero bytes. On a healthy volume even the aborted handle happens to accept a
+// re-arm, so "events resume" alone cannot tell recovery from the old blind
+// re-arm -- the log assertion pins the recovery path. After a real volume
+// reset only a recreated handle delivers events again (ONC-5571).
+func TestRecreateHandleAfterFailedCompletion(t *testing.T) {
+	lc := &logCapture{}
+	SetLogger(lc.log)
+	defer SetLogger(nil)
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(target, []byte("0"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := make(chan EventInfo, 256)
+	r := newWatcher(c).(*readdcw)
+	defer r.Close()
+
+	// A Write-only filter creates a single grip (no directory grip), so there
+	// is exactly one pending I/O to abort.
+	if err := r.Watch(dir, Write); err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	awaitEvent := func(stage string) {
+		t.Helper()
+		deadline := time.After(10 * time.Second)
+		tick := time.NewTicker(200 * time.Millisecond)
+		defer tick.Stop()
+		payload := []byte(stage)
+		for {
+			select {
+			case <-c:
+				return
+			case <-tick.C:
+				// Keep rewriting: the watcher may still be (re)arming.
+				payload = append(payload, 'x')
+				if err := os.WriteFile(target, payload, 0644); err != nil {
+					t.Fatalf("%s: write: %v", stage, err)
+				}
+			case <-deadline:
+				t.Fatalf("%s: no event within 10s -- watcher is dead", stage)
+			}
+		}
+	}
+
+	awaitEvent("before-failure")
+
+	r.Lock()
+	wd, ok := r.m[dir]
+	if !ok || wd.digrip[0] == nil {
+		r.Unlock()
+		t.Fatalf("no grip found for %q", dir)
+	}
+	handle := syscall.Handle(wd.digrip[0].handle)
+	r.Unlock()
+
+	if ret, _, err := procCancelIoExRecovery.Call(uintptr(handle), 0); ret == 0 {
+		t.Fatalf("CancelIoEx: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for !lc.contains("recreating the watch handle") {
+		if time.Now().After(deadline) {
+			t.Fatal("failed completion was not detected within 5s (error discarded?)")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// drain events emitted before the failure so the next await is genuine
+	for {
+		select {
+		case <-c:
+			continue
+		default:
+		}
+		break
+	}
+
+	awaitEvent("after-recovery")
+}


### PR DESCRIPTION
## Summary

Found while investigating DIV-12193 / ONC-5571: a customer's Windows watcher went silently dead mid-session -- the agent kept reporting "Synced" while on-disk changes were invisible until restart. Third occurrence for this customer.

The investigation found a defect in the completion loop (`watcher_readdcw.go`):
- `loop()` assigns the `GetQueuedCompletionStatus` error and never reads it; the first use is the reassignment on the re-arm line.
- A failed completion (I/O aborted by a filter driver, volume reset) is treated like a healthy empty one: the loop re-arms the same handle.
- The re-arm can report success while Windows never posts another completion for that handle -- the watch is dead, with zero log output. The DIV-10969 logging cannot see this: the error is received and thrown away before any logged branch.
- Verified on Windows Server 2022: an aborted watch delivers errno 995 with a valid completion packet and `n == 0`, and v0.9.16 discards it (repro evidence on ONC-5571).

**Is this what happened to the customer? Unknown -- and unknowable from the bundle.** A swallowed error packet and a completion that never arrived both end in the same state: loop parked in `GetQueuedCompletionStatus`, zero logs. The discarded error is exactly the evidence that would have told them apart. After this PR the two cases are distinguishable: a stall with the new error log is this bug (and self-heals); a stall with no log is the no-packet class below.

## The change

- Route completions dequeued with an error to a new `handleFailedCompletion`:
  - log the error, close the (likely dead) handle, and open a fresh one -- `CreateFile` + completion-port associate + re-arm -- instead of blindly re-arming the dead one.
  - failures caused by our own unwatch/rewatch teardown keep the existing state-machine path (`loopstate`).
  - completions for already-closed handles stay a no-op, as before.
- Healthy completions are handled exactly as before.
- Regression test: abort the pending I/O with `CancelIoEx` (same packet a filter driver or volume reset produces), assert the recovery path runs and events keep flowing. On a healthy volume an aborted handle happens to accept a re-arm, so the test pins the recovery path through the log, not only through event delivery.

## What this does not cover

- The "no packet at all" class: a volume detach kills the watch without delivering any completion (verified with a VHDX detach/reattach -- watcher dies, zero packets, zero logs). Nothing arrives for this code to handle; detection for that class is the periodic watcher probe tracked in DIV-9219. Both fixes are needed, and if the customer's stalls are this class, only DIV-9219 helps them.

## Test plan

- [x] Regression test FAILS on unpatched v0.9.16 (aborted completion never detected) and PASSES with the fix -- run on Windows Server 2022
- [x] Full test suite passes with the fix (Windows Server 2022)
- [x] Host build + cross-compile (windows, linux, darwin, freebsd)
- [x] `gofmt` clean; `go vet` -- no new findings (the two `testing_test.go` findings predate this PR)

Generated with Claude Code
